### PR TITLE
[harbour-storeman.desktop] Align with `./debug/harbour-storeman-debug.desktop`

### DIFF
--- a/sailjail/harbour-storeman.desktop
+++ b/sailjail/harbour-storeman.desktop
@@ -10,10 +10,9 @@ X-Maemo-Method=harbour.storeman.service.openPage
 
 [X-Sailjail]
 Sandboxing=enabled
-Permissions=ApplicationInstallation;Internet;MediaIndexing;Documents;Downloads
+Permissions=Internet;Notifications;Secrets;Connman;ApplicationInstallation;MediaIndexing;Downloads;Documents
 # specifying nothing will just use the same as previously - might be read-only though...
 # see https://github.com/storeman-developers/harbour-storeman/issues/236#issuecomment-1072823747
-#
 #OrganizationName=harbour-storeman
 #ApplicationName=harbour-storeman
 # this is interesting: what does DataDirectory do exactly?


### PR DESCRIPTION
…, though I am not sure, if each of these SailJail permissions are really needed (well all make sense, only for `Connman` I am not sure it is needed), `Secrets` and `Notifications` were definitely missing before and rather have initially too many permissions to downselect them (which can be easily done with a text editor on device) than vice versa.

*Edit (from PR #5):* [Line 8](https://github.com/storeman-developers/harbour-storeman/blob/devel/harbour-storeman.pro#L8) and [line 31](https://github.com/storeman-developers/harbour-storeman/blob/devel/harbour-storeman.pro#L31) in `harbour-storeman.pro` indicate that the `Connman` privilege ought to be granted.

Still I wonder, if `OrganizationName=harbour-storeman` and `ApplicationName=harbour-storeman` have to be uncommented to let Storeman use its extant configuration files?
Furthermore I have no idea what `ApplicationName=Storeman` and `DataDirectory=harbour-storeman` might be good for, which are also currently marked as comments!?!