### PR TITLE
[harbour-storeman.desktop] Trying to obtain an exhaustive set of SailJail permissions

### DIFF
--- a/sailjail/debug/harbour-storeman-debug.desktop
+++ b/sailjail/debug/harbour-storeman-debug.desktop
@@ -12,7 +12,7 @@ X-Maemo-Method=harbour.storeman.service.openPage
 Sandboxing=enabled
 # Reference: https://github.com/sailfishos/sailjail-permissions#permissions
 # Permissions are listed in the order they appear there.  Unsure if `AppLaunch` is needed, because
-# the description does not fit to its name.  Even less sure about `MediaIndexing` and `Connman`.
+# the description does not fit to its name.  Even less sure about `MediaIndexing`.
 # `UserDirs` is not used, because we do not want access to Music, Pictures and Videos.
 # Added `WebView;Base;Compatibility;GnuPG;Privileged` only to this `debug.desktop` file.
 Permissions=AppLaunch;ApplicationInstallation;Documents;Downloads;Internet;MediaIndexing;PublicDir;RemovableMedia;Secrets;WebView;Base;Compatibility;Connman;GnuPG;Notifications;Privileged;Sharing

--- a/sailjail/debug/harbour-storeman-debug.desktop
+++ b/sailjail/debug/harbour-storeman-debug.desktop
@@ -10,7 +10,12 @@ X-Maemo-Method=harbour.storeman.service.openPage
 
 [X-Sailjail]
 Sandboxing=enabled
-Permissions=Internet;Notifications;Secrets;Connman;ApplicationInstallation;MediaIndexing;Downloads;Documents
+# Reference: https://github.com/sailfishos/sailjail-permissions#permissions
+# Permissions are listed in the order they appear there.  Unsure if `AppLaunch` is needed, because
+# the description does not fit to its name.  Even less sure about `MediaIndexing` and `Connman`.
+# `UserDirs` is not used, because we do not want access to Music, Pictures and Videos.
+# Added `WebView;Base;Compatibility;GnuPG;Privileged` only to this `debug.desktop` file.
+Permissions=AppLaunch;ApplicationInstallation;Documents;Downloads;Internet;MediaIndexing;PublicDir;RemovableMedia;Secrets;WebView;Base;Compatibility;Connman;GnuPG;Notifications;Privileged;Sharing
 # specifying nothing will just use the same as previously - might be read-only though...
 # see https://github.com/storeman-developers/harbour-storeman/issues/236#issuecomment-1072823747
 #OrganizationName=harbour-storeman

--- a/sailjail/harbour-storeman.desktop
+++ b/sailjail/harbour-storeman.desktop
@@ -12,7 +12,7 @@ X-Maemo-Method=harbour.storeman.service.openPage
 Sandboxing=enabled
 # Reference: https://github.com/sailfishos/sailjail-permissions#permissions
 # Permissions are listed in the order they appear there.  Unsure if `AppLaunch` is needed, because
-# the description does not fit to its name.  Even less sure about `MediaIndexing` and `Connman`.
+# the description does not fit to its name.  Even less sure about `MediaIndexing`.
 # `UserDirs` is not used, because we do not want access to Music, Pictures and Videos.
 Permissions=AppLaunch;ApplicationInstallation;Documents;Downloads;Internet;MediaIndexing;PublicDir;RemovableMedia;Secrets;Connman;Notifications;Sharing
 # specifying nothing will just use the same as previously - might be read-only though...

--- a/sailjail/harbour-storeman.desktop
+++ b/sailjail/harbour-storeman.desktop
@@ -10,7 +10,11 @@ X-Maemo-Method=harbour.storeman.service.openPage
 
 [X-Sailjail]
 Sandboxing=enabled
-Permissions=Internet;Notifications;Secrets;Connman;ApplicationInstallation;MediaIndexing;Downloads;Documents
+# Reference: https://github.com/sailfishos/sailjail-permissions#permissions
+# Permissions are listed in the order they appear there.  Unsure if `AppLaunch` is needed, because
+# the description does not fit to its name.  Even less sure about `MediaIndexing` and `Connman`.
+# `UserDirs` is not used, because we do not want access to Music, Pictures and Videos.
+Permissions=AppLaunch;ApplicationInstallation;Documents;Downloads;Internet;MediaIndexing;PublicDir;RemovableMedia;Secrets;Connman;Notifications;Sharing
 # specifying nothing will just use the same as previously - might be read-only though...
 # see https://github.com/storeman-developers/harbour-storeman/issues/236#issuecomment-1072823747
 #OrganizationName=harbour-storeman


### PR DESCRIPTION
Second thoughts, considerations and documentation following PR #4.

P.S.: [Line 8](https://github.com/storeman-developers/harbour-storeman/blob/devel/harbour-storeman.pro#L8) and [line 31](https://github.com/storeman-developers/harbour-storeman/blob/devel/harbour-storeman.pro#L31) in `harbour-storeman.pro` indicate that the `Connman` privilege ought to be granted.